### PR TITLE
Add linting check to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "11"
+script: npm run lint


### PR DESCRIPTION
This currently just runs `prettier --check`. 

We should also run an `ocamlformat --check`, although this requires installing OCaml.