### PR TITLE
Add syntax highlighting to Shell/OCaml code fences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
+_opam/
 _build/
 .cache/
 public/
 node_modules/
+
+*.install
 *.merlin
 .#*
 package-lock.json

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,1 @@
+require("prismjs/themes/prism-tomorrow.css");

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,7 +25,7 @@ module.exports = {
             options: {
               classPrefix: "language-",
               inlineCodeMarker: null,
-              aliases: {},
+              aliases: { shell: "shell-session" },
               showLineNumbers: false,
               noInlineHighlight: true
             }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,7 @@
 import React from "react";
+import Prism from "prismjs";
+import "prismjs/components/prism-ocaml";
+import "prismjs/components/prism-shell-session";
 import { Link } from "gatsby";
 
 import HomeHeader from "../components/home/homeHeader";
@@ -11,170 +14,183 @@ import imgLicense from "../images/icons/license.png";
 
 import exampleCode from "raw-loader!../data/example.ml";
 
-const HomePage = () => {
-  return (
-    <Layout title="Irmin">
-      <HomeHeader />
-      <HomeFeatureGrid />
+class HomePage extends React.Component {
+  componentDidMount() {
+    Prism.highlightAll();
+  }
 
-      <div className="wrapper">
-        <section className="doc">
-          <div className="colleft">
-            <h2>Installation</h2>
+  render() {
+    return (
+      <Layout title="Irmin">
+        <HomeHeader />
+        <HomeFeatureGrid />
+
+        <div className="wrapper">
+          <section className="doc">
+            <div className="colleft">
+              <h2>Installation</h2>
+              <p>
+                To install Irmin, the command-line tool and all optional
+                dependencies using opam:
+              </p>
+              <pre>
+                <code className="language-shell-session">
+                  $ opam install irmin-unix
+                </code>
+              </pre>
+
+              <p>
+                A minimal installation, with no storage backends can be
+                installed by running:
+              </p>
+              <pre>
+                <code className="language-shell-session">
+                  $ opam install irmin
+                </code>
+              </pre>
+
+              <p>To only install the in-memory storage backend:</p>
+              <pre>
+                <code className="language-shell-session">
+                  $ opam install irmin-mem
+                </code>
+              </pre>
+              <br />
+              <br />
+              <br />
+            </div>
+
+            <div className="colright">
+              <br />
+              <br />
+              <br />
+              <p>The following packages have been made available on opam:</p>
+
+              <ul>
+                <li>
+                  <code>irmin</code> - the base package, no storage
+                  implementations
+                </li>
+                <li>
+                  <code>irmin-chunk</code> - chunked storage
+                </li>
+                <li>
+                  <code>irmin-fs</code> - filesystem-based storage using
+                  bin_prot
+                </li>
+                <li>
+                  <code>irmin-git</code> - Git compatible storage
+                </li>
+                <li>
+                  <code>irmin-http</code> - a simple REST interface
+                </li>
+                <li>
+                  <code>irmin-mem</code> - in-memory storage implementation
+                </li>
+                <li>
+                  <code>irmin-mirage</code> - mirage compatibility
+                </li>
+                <li>
+                  <code>irmin-unix</code> - unix compatibility
+                </li>
+              </ul>
+
+              <p>
+                For more information about an individual package consult the
+                online documentation.
+              </p>
+            </div>
+          </section>
+
+          <div className="clearfix"></div>
+
+          <section className="doc">
+            <h2>Examples</h2>
             <p>
-              To install Irmin, the command-line tool and all optional
-              dependencies using opam:
+              Below is a simple example of setting a key and getting the value
+              out of a Git based, filesystem-backed store.
             </p>
+
             <pre>
-              <code>opam install irmin-unix</code>
+              <code
+                className="language-ocaml"
+                dangerouslySetInnerHTML={{ __html: exampleCode }}
+              ></code>
             </pre>
 
             <p>
-              A minimal installation, with no storage backends can be installed
-              by running:
+              To compile the example above, save it to a file called example.ml
+              and run:
             </p>
             <pre>
-              <code>opam install irmin</code>
-            </pre>
-
-            <p>To only install the in-memory storage backend:</p>
-            <pre>
-              <code>opam install irmin-mem</code>
-            </pre>
-            <br />
-            <br />
-            <br />
-          </div>
-
-          <div className="colright">
-            <br />
-            <br />
-            <br />
-            <p>The following packages have been made available on opam:</p>
-
-            <ul>
-              <li>
-                <code>irmin</code> - the base package, no storage
-                implementations
-              </li>
-              <li>
-                <code>irmin-chunk</code> - chunked storage
-              </li>
-              <li>
-                <code>irmin-fs</code> - filesystem-based storage using bin_prot
-              </li>
-              <li>
-                <code>irmin-git</code> - Git compatible storage
-              </li>
-              <li>
-                <code>irmin-http</code> - a simple REST interface
-              </li>
-              <li>
-                <code>irmin-mem</code> - in-memory storage implementation
-              </li>
-              <li>
-                <code>irmin-mirage</code> - mirage compatibility
-              </li>
-              <li>
-                <code>irmin-unix</code> - unix compatibility
-              </li>
-            </ul>
-
-            <p>
-              For more information about an individual package consult the
-              online documentation.
-            </p>
-          </div>
-        </section>
-
-        <div className="clearfix"></div>
-
-        <section className="doc">
-          <h2>Examples</h2>
-          <p>
-            Below is a simple example of setting a key and getting the value out
-            of a Git based, filesystem-backed store.
-          </p>
-
-          <pre>
-            <code
-              className="language-ocaml"
-              dangerouslySetInnerHTML={{ __html: exampleCode }}
-            ></code>
-          </pre>
-
-          <p>
-            To compile the example above, save it to a file called example.ml
-            and run:
-          </p>
-          <pre>
-            <code>
-              {`$ ocamlfind ocamlopt example.ml -o example -package irmin-unix,lwt.unix -linkpkg
+              <code className="language-shell-session">
+                {`$ ocamlfind ocamlopt example.ml -o example -package irmin-unix,lwt.unix -linkpkg
 $ ./example
 foo/bar => 'testing 123'`}
-            </code>
-          </pre>
+              </code>
+            </pre>
 
-          <p>
-            The examples directory contains some more advanced examples. The
-            build them, run:
-          </p>
-          <pre>
-            <code>
-              {`$ jbuilder build examples/trees.exe
+            <p>
+              The examples directory contains some more advanced examples. The
+              build them, run:
+            </p>
+            <pre>
+              <code className="language-shell-session">
+                {`$ jbuilder build examples/trees.exe
 $ _build/default/examples/trees.exe`}
-            </code>
-          </pre>
+              </code>
+            </pre>
 
-          <h2>Command-line</h2>
-          <p>
-            The same thing can also be accomplished using irmin, the
-            command-line application installed with irmin-unix, by running:
-          </p>
+            <h2>Command-line</h2>
+            <p>
+              The same thing can also be accomplished using irmin, the
+              command-line application installed with irmin-unix, by running:
+            </p>
 
-          <pre className="command-line" data-prompt="$">
-            <code>
-              {`$ echo "root: ." > irmin.yml
+            <pre>
+              <code className="language-shell-session">
+                {`$ echo "root: ." > irmin.yml
 $ irmin init
 $ irmin set foo/bar "testing 123"
 $ irmin get foo/bar`}
-            </code>
-          </pre>
+              </code>
+            </pre>
 
-          <p>
-            irmin.yml allows for irmin flags to be set on a per-directory basis.
-            You can also set flags globally using{" "}
-            <code>$HOME/.irmin/config.yml</code>. Run irmin help irmin.yml for
-            further details.
-          </p>
+            <p>
+              irmin.yml allows for irmin flags to be set on a per-directory
+              basis. You can also set flags globally using{" "}
+              <code>$HOME/.irmin/config.yml</code>. Run irmin help irmin.yml for
+              further details.
+            </p>
 
-          <h2>Explore further</h2>
+            <h2>Explore further</h2>
 
-          <p>
-            <Link to="/tutorial/introduction" className="button tutorial">
-              <img src={imgTutorial} alt="" /> Tutorial
-            </Link>
-            <a
-              className="button issue"
-              href="https://github.com/mirage/irmin/issues"
-            >
-              <img src={imgIssue} alt="" /> Issues
-            </a>
-            <a
-              className="button license"
-              href="https://github.com/mirage/irmin/blob/master/LICENSE.md"
-            >
-              <img src={imgLicense} alt="" /> License
-            </a>
-          </p>
-          <p>
-            Development of Irmin was supported in part by the EU FP7
-            User-Centric Networking project, Grant No. 611001.
-          </p>
-        </section>
-      </div>
-    </Layout>
-  );
-};
+            <p>
+              <Link to="/tutorial/introduction" className="button tutorial">
+                <img src={imgTutorial} alt="" /> Tutorial
+              </Link>
+              <a
+                className="button issue"
+                href="https://github.com/mirage/irmin/issues"
+              >
+                <img src={imgIssue} alt="" /> Issues
+              </a>
+              <a
+                className="button license"
+                href="https://github.com/mirage/irmin/blob/master/LICENSE.md"
+              >
+                <img src={imgLicense} alt="" /> License
+              </a>
+            </p>
+            <p>
+              Development of Irmin was supported in part by the EU FP7
+              User-Centric Networking project, Grant No. 611001.
+            </p>
+          </section>
+        </div>
+      </Layout>
+    );
+  }
+}
 
 export default HomePage;


### PR DESCRIPTION
This uses the PrismJS `ocaml` and `shell-session` languages.

The shell highlighting looks a bit off to me (it highlights `git` even when not being used as a command, for instance. Perhaps the keywords could be tweaked in future to fix this.