### PR TITLE
Add missing GraphQL tutorial to index

### DIFF
--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -19,6 +19,7 @@ export default function Template({ data }) {
     },
     { link: "/tutorial/contents", title: "Custom content types" },
     { link: "/tutorial/backend", title: "Writing a storage backend" },
+    { link: "/tutorial/graphql", title: "GraphQL bindings" },
     { link: "/tutorial/resources", title: "Resources" }
   ];
 


### PR DESCRIPTION
The tutorial index is currently specified manually in `tutorial.js`, leading to this error.

We might be able to generate this index dynamically using a GraphQL query (as suggested [here](https://github.com/tarides/irmin.io/blob/master/src/templates/tutorial.js#L12)), but this would require some ordering mechanism.